### PR TITLE
修复单线程运行bug

### DIFF
--- a/include/cinatra/cinatra.hpp
+++ b/include/cinatra/cinatra.hpp
@@ -170,7 +170,7 @@ namespace cinatra
 
 	private:
 #ifndef CINATRA_SINGLE_THREAD
-	int num_threads_ = 0;
+	int num_threads_ = 1;
 #else
 	int num_threads_ = std::thread::hardware_concurrency();
 #endif // CINATRA_SINGLE_THREAD


### PR DESCRIPTION
num_threads_为0，将导致运行时抛异常，异常如下：
terminate called after throwing an instance of 'std::runtime_error'
  what():  io_service_pool size is 0
